### PR TITLE
Installation help time fix

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -38,7 +38,7 @@ The schedule includes frequent breaks.
 
 **Installation help and verification times** (drop in)
 - May 5 (Wednesday) 13:00-14:00 CET
-- May 6 (Thursday) 14:00-15:00 CET
+- May 6 (Thursday) 10:00-11:00 CET
 
 **Day 1 (May 10, Monday)**
 - 9:00 - 9:20


### PR DESCRIPTION
For some reason, the installation help time on the 6th May was incorrectly written. Corrected to the agreed time, 10:00-11:00 CET.