### PR TITLE
Pre-opening fixes

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -43,7 +43,7 @@ The schedule includes frequent breaks.
 **Day 1 (May 10, Monday)**
 - 9:00 - 9:20
   [Welcome and practical information](https://github.com/coderefinery/workshop-intro/blob/master/README.md)
-  (TBA)
+  (Sabry Razick)
 - 9:20 - 12:30
   [Introduction to version control - part 1/2](https://coderefinery.github.io/git-intro/) ("Motivation" to "Undoing")
   (Diana Iusan, Juho Lehtonen, and Sabry Razick)
@@ -61,7 +61,7 @@ The schedule includes frequent breaks.
 **Day 4 (May 18, Tuesday)**
 - 9:00 - 9:15
   [Mini-intro](https://github.com/coderefinery/workshop-intro/blob/master/README.md)
-  (TBA)
+  (Johan Hellsvik)
 - 9:00 - 11:15
   [Reproducible research and FAIR data](https://coderefinery.github.io/reproducible-research/)
   (Johan Hellsvik)
@@ -86,26 +86,35 @@ The schedule includes frequent breaks.
   (Anne Fouilloux)
 - 12:15 - 12:30
   [Concluding remarks and where to go from here](https://github.com/coderefinery/workshop-outro/blob/master/README.md)
-  (TBA)
+  (Radovan Bast)
 
+
+#### Coordinators
+- Radovan Bast
+- Richard Darst
+- Diana Iusan
+- Naoe Tatara
+- Samantha Wittke
 
 #### Host
 - Richard Darst
 
-#### Instructors
+#### Instructors and expert helpers
 
 - Radovan Bast
 - Anne Fouilloux
 - Johan Hellsvik
+- Patric Holmvall
 - Diana Iusan
 - Juho Letonen
+- Stefan Negru
 - Sabry Razick
 - Thor Wikfeldt
 - Samantha Wittke
 
 
-#### Helpers
+#### Exercise leaders
 
-[Be a helper](volunteer/)
+[Be an exercise leader](volunteer/)
 
 - TBA

--- a/content/audience.md
+++ b/content/audience.md
@@ -42,6 +42,6 @@ examples is Python (but we do have examples in other languages, too).
 Do you know some of the topics, but want to review them, why not
 attend as an exercise leader?  You don't need to be an expert: if you
 have been through CodeRefinery once or have some familiarity with the
-topics, and you are confident to call a helper when needed, then you
+topics, and you are confident to call an expert helper when needed, then you
 have all it takes to lead a team to success.  [Read more
 here](../volunteer/).

--- a/content/join.md
+++ b/content/join.md
@@ -4,7 +4,7 @@ title = "How to join"
 
 ## How to join
 
-We are normally limited by number of helpers, thus:
+We are normally limited by number of expert helpers and individual exercise leaders, thus we have two options:
 
 ### Zoom registration
 
@@ -12,33 +12,19 @@ In Zoom, we group attendees into teams, with an exercise leader.  This
 is a very interactive workshop.
 
 - Anyone may register as a learner, we will try to take as many as we can.
-- Complete teams are preferred: one helper and 4-6 learners:
+- Complete teams are preferred: one exercise leader and 4-6 learners:
   - Everyone on the team must register separately.
   - Decide on a team name, and provide it when registering,
     so that we can link teammates together.
-  - During the exercise sessions in breakout rooms, the helper has
+  - During the exercise sessions in breakout rooms, the exercise leader has
     primary responsibility for their group's hands-on exercises.
-    Still, instructors drop by to check and help
-    as needed, so don't worry if as a helper you don't know everything.
+    Still, instructors/expert helpers drop by to check and help
+    as needed, so don't worry if as an exercise leader you don't know everything.
   - This is a great opportunity to bring your friends and colleagues
-    and prepare for the future together.
+    and prepare for the future together. If you will work together later,
+    learning the tools at the same time is a great way to do it.
 - If you routinely use Git and know Python somewhat well or you've been to
-  a CodeRefinery before, you are definitely capable of being a helper and register as one!
-
-**Why should I come as a team?**  If you will work together later,
-  learning the tools at the same time is a great way to do it.
-
-**Am I good enough to be a helper?**  If you are asking this
-  question, probably you are.  You should have some familiarity with
-  git, provide some initial advice on obvious error messages, and
-  be able to call us for advanced help when it's needed.
-
-**How does the waiting list work?**  Anyone can register, but you go to
-  the waiting list until we can be sure we have enough helpers.  We'll
-  continually approve people as we get space.  We know
-  this may be more unpredictable for you, but the way to make sure you
-  get in is join a team with a helper (or find us more helpers in
-  general).
+  a CodeRefinery before, you are definitely capable of being an exercise leader and register as one!
 
 ### Attend via live stream
 
@@ -63,7 +49,7 @@ exercises together.
 The course is free of charge, we are funded by the [Nordic e-Infrastructure
 Collaboration](https://neic.no/).
 
-When we have more sign-ups than our capacity allows, the following priority criteria apply:
+When we have more sign-ups as **individual learner** than our capacity allows, the following priority criteria apply:
 
 1. National universities or research institutes in Nordic countries and Estonia
 2. Private companies and government agencies in Nordic countries or Estonia
@@ -73,3 +59,5 @@ When we have more sign-ups than our capacity allows, the following priority crit
 Therefore it is very important that you use an email address
 corresponding to your affiliation.  If you aren't accepted to the Zoom
 session, you can always attend the stream part.
+
+We will accept both **complete teams** (i.e. including at least one exercise leader that can attend all the days) and sign-ups as **exercise leader** as long as the technical capacity of Zoom meeting allows (currently it is 300).

--- a/content/requirements.md
+++ b/content/requirements.md
@@ -43,7 +43,7 @@ page. **You also need to check your git configuration**
 - [Zoom](https://coderefinery.github.io/installation/zoom/)
 
 **You should either a) drop by one of our verification sessions in
-advance, or b) verify with your team's helper before the workshop.**
+advance, or b) verify with your team's exercise leader before the workshop.**
 
 If you have an institutional laptop with limited rights, start in advance
 and/or ask for help to translate these instructions to work on your system.:

--- a/content/volunteer.md
+++ b/content/volunteer.md
@@ -33,8 +33,8 @@ be able to call us for advanced help when it's needed.
 form has an option for this registration option.
 
 **Teams?**  If you have friends or colleagues you would like to
-mentor, register as part of a team.  First off, if a team has a
-helper, it will almost certainly be accepted.  Second, working
+mentor, register as part of a team.  First off, if a team has an
+exercise leader, it will almost certainly be accepted.  Second, working
 together makes it much more likely to have a lasting effect.
 
 


### PR DESCRIPTION
- Fixed "helper" to "exercise leaders" and where necessary to "expert helper"
- Clarification of who priority criteria applies
- Removal of some overlapping info and move of info to more appropriate place
- Added names to intro/mini-intro/concluding remarks
- Added names and roles (coordinators, expert helpers)