### PR TITLE
made software installation instruction more findable and visible

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -9,6 +9,8 @@ exercise leader, you might still be accepted.
 
 Registration confirmations will come within this week.
 
+<span style="color:darkred;font-weight:bold">If you received registration confirmation, please follow the software installation instructions and checklist on [this page](https://coderefinery.github.io/installation/).</span>
+
 ## Course goals
 
 In this course, you will become familiar with tools and best practices


### PR DESCRIPTION
I added a line below the registration-related place on the index page.
![image](https://user-images.githubusercontent.com/56588774/116619967-796bac00-a941-11eb-9a9a-27800b914164.png)
